### PR TITLE
Ids instead of names

### DIFF
--- a/lib/composition/index.js
+++ b/lib/composition/index.js
@@ -176,7 +176,7 @@ Composition.prototype.addInstance = function (cInstance, isServer) {
       ;
 
     cNode = self.addNode(cInstance, isServer);
-    info = self.appService.e[cNode.name];
+    info = self.appService.e[cNode.id];
 
     if (info) {
         if (info.color) {


### PR DESCRIPTION
Use the id instead of name when saving the positions and colors
